### PR TITLE
Add support for UNIX domain sockets

### DIFF
--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -39,6 +39,7 @@ export function createFetch(got: Got): GotFetch {
 
     const mergedOptions = gotGlobal.mergeOptions(got.defaults.options, {
       url: url.toString(),
+      searchParams: undefined,
       followRedirect: true,
       throwHttpErrors: false,
       method: (request.method as any) || 'get',

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -40,6 +40,10 @@ export function createFetch(got: Got): GotFetch {
     const mergedOptions = gotGlobal.mergeOptions(got.defaults.options, {
       url: url.toString(),
       searchParams: undefined,
+      // url needs to be stringified to support UNIX domain sockets, and
+      // searchParams need to be set to undefined to prevent potential issues in
+      // Got. For more info see https://github.com/alexghr/got-fetch/pull/8
+
       followRedirect: true,
       throwHttpErrors: false,
       method: (request.method as any) || 'get',

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -38,7 +38,7 @@ export function createFetch(got: Got): GotFetch {
     appendSearchParams(url.searchParams, defaultSearchParams);
 
     const mergedOptions = gotGlobal.mergeOptions(got.defaults.options, {
-      url,
+      url: url.toString(),
       followRedirect: true,
       throwHttpErrors: false,
       method: (request.method as any) || 'get',


### PR DESCRIPTION
Got accepts UNIX domain socket URLs but only in string form.
WHATWG URL objects are not accepted. For this reason URLs must be
cast to strings before the options are passed to Got.

Reference: https://github.com/sindresorhus/got#unix-domain-sockets