### PR TITLE
Content-Length header should be set properly for multi-byte characters

### DIFF
--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -112,7 +112,7 @@ function serializeBody(body: BodyInit | null | undefined): Pick<GotOptions, 'bod
       body,
       headers: {
         'Content-Type': 'text/plain; charset=utf-8',
-        'Content-Length': String(body.length)
+        'Content-Length': String(Buffer.byteLength(body, 'utf8')),
       }
     };
   } else if (Buffer.isBuffer(body) || (body instanceof Readable)) {

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -104,7 +104,7 @@ function serializeBody(body: BodyInit | null | undefined): Pick<GotOptions, 'bod
       body: serialized,
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8',
-        'Content-Length': String(serialized.length)
+        'Content-Length': String(Buffer.byteLength(serialized, 'utf8'))
       }
     }
   } else if (typeof body === 'string') {

--- a/src/test/fetch.request.test.ts
+++ b/src/test/fetch.request.test.ts
@@ -146,7 +146,7 @@ describe('fetch request', () => {
       }));
     });
 
-    it('sends the correct content-length on a multi-byte character', async () => {
+    it('sends the correct content-length on a multi-byte character for string payloads', async () => {
       expect.assertions(1);
       interceptor
         .intercept('/', 'post')
@@ -158,7 +158,21 @@ describe('fetch request', () => {
         method: 'post',
         body: "𐍈"
       }));
-      
-    })
+    });
+
+    it('sends the correct content-length on a multi-byte character for url search param payloads', async () => {
+      expect.assertions(1);
+      interceptor
+        .intercept('/', 'post')
+        .matchHeader('Content-Length', '16')
+        .reply(200);
+
+      const fetch = createFetch(got);
+      await assert200(fetch(url('/'), {
+        method: 'post',
+        body: new URLSearchParams({ foo: "𐍈"})
+      }));
+
+    });
   });
 });

--- a/src/test/fetch.request.test.ts
+++ b/src/test/fetch.request.test.ts
@@ -145,5 +145,20 @@ describe('fetch request', () => {
         method: 'post',
       }));
     });
+
+    it('sends the correct content-length on a multi-byte character', async () => {
+      expect.assertions(1);
+      interceptor
+        .intercept('/', 'post')
+        .matchHeader('Content-Length', '4')
+        .reply(200);
+
+      const fetch = createFetch(got);
+      await assert200(fetch(url('/'), {
+        method: 'post',
+        body: "𐍈"
+      }));
+      
+    })
   });
 });


### PR DESCRIPTION
Fixes #13 

As mentioned in the ticket, this should probably be passed along to got and not solved this way, but this is an interim solution.