### PR TITLE
fix: Allow prefixUrl to work

### DIFF
--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -13,7 +13,7 @@ export function createFetch(got: Got): GotFetch {
   return async (input, opts) => {
     let url = input.toString();
     let searchParams: URLSearchParams = new URLSearchParams();
-    
+
     try {
       const urlObj = new URL(
         typeof input === "string"
@@ -61,6 +61,7 @@ export function createFetch(got: Got): GotFetch {
       // url needs to be stringified to support UNIX domain sockets, and
       // For more info see https://github.com/alexghr/got-fetch/pull/8
       url,
+      searchParams,
       followRedirect: true,
       throwHttpErrors: false,
       method: (request.method as Method) || 'get',

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -12,13 +12,30 @@ export function createFetch(got: Got): GotFetch {
 
   return async (input, opts) => {
     let url = input.toString();
+    let searchParams: URLSearchParams = new URLSearchParams();
+    
     try {
-      url = new URL(typeof input === 'string' ? input : input.url).toString();
+      const urlObj = new URL(
+        typeof input === "string"
+          ? input
+          : input.url
+      );
+
+      searchParams = new URLSearchParams(urlObj.searchParams);
+      urlObj.search = "";
+
+      url = urlObj.href;
     } catch (e) {
       // Ignore url parsing failure, likely prefixUrl is being used
       // When using prefixUrl, the path cannot start with a "/"
       if (url.startsWith("/")) {
         url = url.substring(1);
+      }
+
+      if (url.includes("?")) {
+        const [path, search] = url.split("?");
+        url = path;
+        searchParams = new URLSearchParams(search);
       }
     }
     const request: RequestInit = typeof input === 'object' ? input : opts || {};

--- a/src/test/fetch.request.test.ts
+++ b/src/test/fetch.request.test.ts
@@ -2,7 +2,7 @@ import got from 'got';
 import { URLSearchParams } from 'url';
 
 import { createFetch } from '../lib/fetch';
-import { Interceptor, intercept, assert200, url } from './util';
+import { Interceptor, intercept, assert200, url, ORIGIN } from './util';
 
 describe('fetch request', () => {
   let interceptor: Interceptor;
@@ -37,6 +37,18 @@ describe('fetch request', () => {
       const fetch = createFetch(got);
       await assert200(fetch(url('/foo')));
     });
+
+    it('allows prefixUrl', async () => {
+      expect.assertions(1);
+      interceptor.intercept('/foo', 'get').reply(200);
+
+      const prefixedClient = got.extend({
+        prefixUrl: ORIGIN
+      })
+
+      const fetch = createFetch(prefixedClient);
+      await assert200(fetch('/foo'));
+    });
   });
 
   describe('querystring', () => {
@@ -48,13 +60,6 @@ describe('fetch request', () => {
       await assert200(fetch(url('/', { foo: '123', bar: '456' })));
     });
 
-    it('merges query string parameters', async () => {
-      expect.assertions(1);
-      interceptor.intercept('/', 'get').query({ foo: '123', bar: '456' }).reply(200);
-
-      const fetch = createFetch(got.extend({ searchParams: { bar: '456' } }));
-      await assert200(fetch(url('/', { foo: '123' })));
-    });
   });
 
   describe('headers', () => {
@@ -175,7 +180,7 @@ describe('fetch request', () => {
 
     });
 
-    it.only("sends own content-type header", async () => {
+    it("sends own content-type header", async () => {
       expect.assertions(1);
 
       // as set by the client

--- a/src/test/fetch.request.test.ts
+++ b/src/test/fetch.request.test.ts
@@ -62,6 +62,27 @@ describe('fetch request', () => {
 
   });
 
+  it('merges query string parameters', async () => {
+    expect.assertions(1);
+    interceptor.intercept('/', 'get').query({ foo: '123', bar: '456' }).reply(200);
+
+    const fetch = createFetch(got.extend({ searchParams: { bar: '456' } }));
+    await assert200(fetch(url('/', { foo: '123' })));
+  });
+
+  it('merges query string parameters with prefixUrl', async () => {
+    expect.assertions(1);
+    interceptor.intercept('/foo', 'get').query({ foo: '123', bar: '456' }).reply(200);
+
+    const prefixedClient = got.extend({
+      prefixUrl: ORIGIN,
+      searchParams: { bar: '456' }
+    })
+
+    const fetch = createFetch(prefixedClient);
+    await assert200(fetch('/foo?foo=123'));
+  });
+
   describe('headers', () => {
     it('sends headers', async () => {
       expect.assertions(1);

--- a/src/test/util.ts
+++ b/src/test/util.ts
@@ -1,7 +1,7 @@
 import nock from 'nock';
 import { URL } from 'url';
 
-const ORIGIN = 'https://example.com';
+export const ORIGIN = 'https://example.com';
 
 export type Interceptor = nock.Scope;
 export function intercept(): Interceptor {


### PR DESCRIPTION
This is most certainly a hack, but I was trying to maintain the current behaviour.
https://github.com/alexghr/got-fetch/issues/369

I can also port this to main